### PR TITLE
Increase tool memory to 3Gi

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -19,7 +19,7 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-      memoryLimit: 1536M
+      memoryLimit: 3Gi
   - name: m2
     volume:
       size: 1G


### PR DESCRIPTION
Increase tool memory to 3Gi.

As far as I can tell it fixes https://github.com/eclipse/che/issues/20464
![Screenshot_20210914_120827](https://user-images.githubusercontent.com/5887312/133229720-50c609bf-21d0-409d-8b59-bb7155b7bef4.png)

but maybe a lower memory limit can be sufficient as well, like 2Gi, 2.5Gi?
But since samples are supposed to host later users projects, I think 3Gi is small enough.