### PR TITLE
chore(dev-image): use universal developer image for tools container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,7 +6,7 @@ attributes:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: quay.io/devfile/universal-developer-image:ubi8-d433ed6
       endpoints:
         - exposure: none
           name: debug


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Uses [latest tag of universal developer image](https://quay.io/repository/devfile/universal-developer-image?tab=tags&tag=ubi8-d433ed6) for tooling container.

Solves https://github.com/eclipse/che/issues/20657