### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -5,7 +5,7 @@ components:
 
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-d433ed6
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 3Gi
       endpoints:
         - exposure: none
@@ -56,20 +56,20 @@ commands:
   - id: prepare-database
     exec:
       component: mariadb
-      workingDir: ${PROJECTS_ROOT}/java-spring-petclinic
+      workingDir: ${PROJECT_SOURCE}
       commandLine: |
-        mysql -u root < ${PROJECTS_ROOT}/java-spring-petclinic/src/main/resources/db/mysql/user.sql && \
-        mysql -u root petclinic < ${PROJECTS_ROOT}/java-spring-petclinic/src/main/resources/db/mysql/schema.sql && \
-        mysql -u root petclinic < ${PROJECTS_ROOT}/java-spring-petclinic/src/main/resources/db/mysql/data.sql && \
+        mysql -u root < ${PROJECT_SOURCE}/src/main/resources/db/mysql/user.sql && \
+        mysql -u root petclinic < ${PROJECT_SOURCE}/src/main/resources/db/mysql/schema.sql && \
+        mysql -u root petclinic < ${PROJECT_SOURCE}/src/main/resources/db/mysql/data.sql && \
         echo "\e[32mDone.\e[0m Database petclinic was configured"
       group:
         kind: run
         isDefault: true
 
-  - id: build
+  - id: maven-build
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/java-spring-petclinic
+      workingDir: ${PROJECT_SOURCE}
       commandLine: mvn clean install
       group:
         kind: build
@@ -78,7 +78,7 @@ commands:
   - id: run-with-hsqldb
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/java-spring-petclinic
+      workingDir: ${PROJECT_SOURCE}
       commandLine: >-
         java -jar target/*.jar
       group:
@@ -88,7 +88,7 @@ commands:
   - id: run-with-mysql
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/java-spring-petclinic
+      workingDir: ${PROJECT_SOURCE}
       commandLine: |
         java -jar -Dspring.profiles.active=mysql \
         -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
@@ -100,7 +100,7 @@ commands:
   - id: run-debug
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/java-spring-petclinic
+      workingDir: ${PROJECT_SOURCE}
       commandLine: >-
         java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 target/*.jar
       group:


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
