### PR TITLE
chore: use maven instead of 'java -jar' to run sample

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "redhat.java"
+    "redhat.java",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test"
   ]
 }

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -79,8 +79,9 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: >-
-        java -jar target/*.jar
+      commandLine: |
+        mvn spring-boot:run -DskipTests \
+        -Dspring-boot.run.jvmArguments='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y'
       group:
         kind: run
         isDefault: true
@@ -90,19 +91,8 @@ commands:
       component: tools
       workingDir: ${PROJECT_SOURCE}
       commandLine: |
-        java -jar -Dspring.profiles.active=mysql \
-        -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
-        target/*.jar
-      group:
-        kind: run
-        isDefault: true
-
-  - id: run-debug
-    exec:
-      component: tools
-      workingDir: ${PROJECT_SOURCE}
-      commandLine: >-
-        java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 target/*.jar
+        mvn spring-boot:run -DskipTests -Dspring-boot.run.profiles=mysql \
+        -Dspring-boot.run.jvmArguments='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y'
       group:
         kind: run
         isDefault: true


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

For commands to run sample, it's better to use `mvn spring-boot:run` instead of `java -jar`

Solves https://github.com/eclipse/che/issues/20791

To test use
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/https://github.com/vitaliy-guliy/java-spring-petclinic/tree/devfilev2&che-editor=che-incubator/che-code/insiders
