### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -13,8 +13,8 @@ components:
           protocol: tcp
           targetPort: 5005
         - exposure: public
-          name: 8080-tcp
-          protocol: http
+          name: 8080-https
+          protocol: https
           targetPort: 8080
       volumeMounts:
         - name: m2


### PR DESCRIPTION
chore: use https protocol in endpoint

Related issue: https://issues.redhat.com/browse/CRW-5377