### PR TITLE
devfile:use schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: spring-petclinic
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_53_14](https://github.com/che-samples/java-spring-petclinic/assets/1271546/bbac9601-74a4-473a-9e05-b95114f7bd93)


Related issue: https://github.com/eclipse/che/issues/21985

